### PR TITLE
Extract database specific adapters.

### DIFF
--- a/lib/boxy-cap/database_adapters/base.rb
+++ b/lib/boxy-cap/database_adapters/base.rb
@@ -1,0 +1,89 @@
+require 'rake'
+module DatabaseAdapters
+  class Base
+    require_relative 'mysql'
+    require_relative 'postgresql'
+    require_relative 'sql_server'
+
+    include FileUtils
+
+    class << self
+      def for(config, database_name)
+        case config[:adapter]
+          when /mysql/
+            MySQL.new(config, database_name)
+          when 'postgresql', 'pg'
+            PostgreSQL.new(config, database_name)
+          when 'sqlserver'
+            SQLServer.new(config, database_name)
+          else
+            fail "Database #{config[:adapter]} is not supported!"
+        end
+      end
+    end
+
+    def initialize(config, database_name)
+      @config = config
+      @database_name = database_name
+      @backup_file = File.join(backup_dir, "#{database_name}_#{datestamp}.dump")
+    end
+
+    def backup
+      mkdir_p(backup_dir)
+      sh backup_command
+      latest_file_name = File.join(backup_dir, "#{database_name}_latest.dump")
+      rm latest_file_name if File.exist?(latest_file_name)
+      safe_ln backup_file, latest_file_name
+    end
+
+    def restore
+      sh "#{restore_command} || echo 'done'"
+    end
+
+    def cleanup_old_database_dumps
+      dumps = FileList.new(File.join(backup_dir, '*.dump')).exclude(/_latest.dump$/)
+
+      if keep_versions > 0 && dumps.count >= keep_versions
+        puts "Keep #{keep_versions} dumps"
+        files = (dumps - dumps.last(keep_versions))
+        if files.any?
+          files.each do |f|
+            rm_r f
+          end
+        end
+      end
+    end
+
+    def kill_connections
+      fail 'Subclass must implement!'
+    end
+
+    protected
+
+    attr_reader :config, :database_name, :backup_file
+
+    def backup_command
+      fail 'Subclass must implement!'
+    end
+
+    def restore_command
+      fail 'Subclass must implement!'
+    end
+
+    private
+
+    def datestamp
+      dateformat = ENV['date-format'] || '%Y-%m-%d_%H-%M-%S'
+      Time.now.strftime(dateformat)
+    end
+
+    def backup_dir
+      @_backup_dir ||= ENV['backup-path'] || Rails.root.join('db', 'backups')
+    end
+
+    def keep_versions
+      @_keep_versions ||= ENV['ROTATE'].to_i
+    end
+  end
+end
+

--- a/lib/boxy-cap/database_adapters/mysql.rb
+++ b/lib/boxy-cap/database_adapters/mysql.rb
@@ -1,0 +1,38 @@
+module DatabaseAdapters
+  class MySQL < Base
+    def kill_connections
+      # no-op. Not implemented for MySQL.
+    end
+
+    protected
+
+    def backup_command
+      mysql_dump_command
+    end
+
+    def restore_command
+      mysql_restore_command
+    end
+
+    private
+
+    def mysql_dump_command
+      result = "mysqldump #{database_name} "
+      result += mysql_auth_options
+      result + " > #{backup_file}"
+    end
+
+    def mysql_restore_command
+      "mysql #{database_name} #{mysql_auth_options} < #{backup_file}"
+    end
+
+    def mysql_auth_options
+      command_options = ''
+      command_options += "--password='#{config[:password]}'" if config[:password].present?
+      command_options += " -h #{config[:host]}" if config[:host].present?
+      command_options += " -u #{config[:username]}" if config[:username].present?
+      command_options
+    end
+  end
+end
+

--- a/lib/boxy-cap/database_adapters/postgresql.rb
+++ b/lib/boxy-cap/database_adapters/postgresql.rb
@@ -1,0 +1,64 @@
+module DatabaseAdapters
+  class PostgreSQL < Base
+    def kill_connections
+      kill_postgres_connections
+    end
+
+    protected
+
+    def backup_command
+      postgres_dump_command
+    end
+
+    def restore_command
+      postgres_restore_command
+    end
+
+    private
+
+    def postgres_dump_command
+      result = "#{postgres_password} pg_dump #{database_name} -w -F c"
+      result += postgres_auth_options
+      result + " > #{backup_file}"
+    end
+
+    def postgres_password
+      "PGPASSWORD='#{config[:password]}'" if config[:password].present?
+    end
+
+    def postgres_auth_options
+      command_options = ''
+      command_options += " -h #{config[:host]}" if config[:host].present?
+      command_options += " -U #{config[:username]}" if config[:username].present?
+      command_options
+    end
+
+    def postgres_restore_command
+      result = "#{postgres_password} pg_restore -d #{database_name} -F c -w #{backup_file}"
+      result += postgres_auth_options
+      result + ' -O -c'
+    end
+
+    def kill_postgres_connections
+      pid_column_name = if ActiveRecord::Base.connection.send(:postgresql_version) > 90200
+                          'pid'
+                        else
+                          'procpid'
+                        end
+
+      kill_query = <<-QUERY
+      SELECT pg_terminate_backend(#{pid_column_name})
+      FROM pg_stat_activity
+      WHERE datname = '#{database_name}';
+      QUERY
+
+      begin
+        ActiveRecord::Base.connection.exec_query(kill_query)
+      rescue ActiveRecord::StatementInvalid => ex
+        puts "All connections to #{db_name} were killed successfully!"
+        puts "Database message: #{ex.message}"
+      end
+    end
+  end
+end
+

--- a/lib/boxy-cap/database_adapters/sql_server.rb
+++ b/lib/boxy-cap/database_adapters/sql_server.rb
@@ -1,0 +1,23 @@
+module DatabaseAdapters
+  class SQLServer
+    def initialize(*)
+    end
+
+    def backup
+      puts 'Not supported'
+    end
+
+    def restore
+      puts 'Not supported'
+    end
+
+    def kill_connections
+      puts 'Not supported'
+    end
+
+    def cleanup_old_database_dumps
+      puts 'Not supported'
+    end
+  end
+end
+

--- a/lib/boxy-cap/tasks/db.rake
+++ b/lib/boxy-cap/tasks/db.rake
@@ -1,152 +1,43 @@
 namespace :db do
-  desc 'Backup Database specific to MySQL of PostgreSQL'
+  require_relative '../database_adapters/base'
+
+  desc 'Backup database'
   task backup: [:environment, :load_config] do
-    #stamp the filename
-    dateformat = ENV['date-format'] || '%Y-%m-%d_%H-%M-%S'
-    datestamp  = Time.now.strftime(dateformat)
-
-    #create backups folder
-    mkdir_p(backup_dir)
-
-    config        = ActiveRecord::Base.connection_config
-    database_name = ActiveRecord::Base.connection.current_database
-    backup_file   = File.join(backup_dir, "#{database_name}_#{datestamp}.dump")
-
-    #dump the backup and zip it up
-    sh dump_command(config, database_name, backup_file)
-
-    latest_file_name = File.join(backup_dir, "#{database_name}_latest.dump")
-    if File.exist? latest_file_name
-      rm latest_file_name
-    end
-    safe_ln backup_file, latest_file_name
+    database_adapter = DatabaseAdapters::Base.for(connection_config, current_database)
+    database_adapter.backup
   end
 
-  desc 'Restore Database Backup specific to MySQL of PostgreSQL, from last backup file'
+  desc 'Restore database from last backup file'
   task restore: ['db:create', :environment, :load_config] do
-    config        = ActiveRecord::Base.connection_config
-    database_name = ActiveRecord::Base.connection.current_database
-    backup_dir    = ENV['backup-path'] || Rails.root.join('db', 'backups')
-    backup_file   = File.join(backup_dir, "#{database_name}_latest.dump")
-
-    execute_task!('db:kill_postgres_connections')
+    database_adapter = DatabaseAdapters::Base.for(connection_config, current_database)
+    database_adapter.kill_connections
     execute_task!('db:drop')
     execute_task!('db:create')
-
-    command = db_restore_command(config, database_name, backup_file)
-    sh "#{command} || echo 'done'"
+    database_adapter.restore
   end
 
-  task :kill_postgres_connections => :environment do
-    config = ActiveRecord::Base.connection_config
-    next if config[:adapter] != "postgresql"
-    db_name         = ActiveRecord::Base.connection.current_database
-    pid_column_name = if ActiveRecord::Base.connection.send(:postgresql_version) > 90200
-                        'pid'
-                      else
-                        'procpid'
-                      end
-
-    kill_query = <<-QUERY
-      SELECT pg_terminate_backend(#{pid_column_name})
-      FROM pg_stat_activity
-      WHERE datname = '#{db_name}';
-    QUERY
-
-    begin
-      ActiveRecord::Base.connection.exec_query(kill_query)
-    rescue ActiveRecord::StatementInvalid => ex
-      puts "All connections to #{db_name} were killed successfully!"
-      puts "Database message: #{ex.message}"
-    end
+  desc 'Kill PostgreSQL connections'
+  task kill_postgres_connections: [:environment, :load_config] do
+    database_adapter = DatabaseAdapters::Base.for(connection_config, current_database)
+    database_adapter.kill_connections
   end
 
-  desc 'Cleanup old Database dumps, and keep only specified number of dumps'
-  task :cleanup do
-    dumps = FileList.new(File.join(backup_dir, '*.dump')).exclude(/_latest.dump$/)
-
-    if keep_versions > 0 && dumps.count >= keep_versions
-      puts "Keep #{keep_versions} dumps"
-      files = (dumps - dumps.last(keep_versions))
-      if files.any?
-        files.each do |f|
-          rm_r f
-        end
-      end
-    end
-
+  desc 'Cleanup old Database dumps and keep only specified number of dumps'
+  task cleanup: [:environment, :load_config] do
+    database_adapter = DatabaseAdapters::Base.for(connection_config, current_database)
+    database_adapter.cleanup_old_database_dumps
   end
 
-  def backup_dir
-    @_backup_dir ||= ENV['backup-path'] || Rails.root.join('db', 'backups')
+  def connection_config
+    ActiveRecord::Base.connection_config
   end
 
-  def keep_versions
-    @_keep_versions ||= ENV['ROTATE'].to_i
+  def current_database
+    ActiveRecord::Base.connection.current_database
   end
 
-  def postgres_dump_command(config, database_name, backup_file)
-    result = "#{postgres_password(config)} pg_dump #{database_name} -w -F c"
-    result += postgres_auth_options(config)
-    result + " > #{backup_file}"
+  def execute_task!(task_name)
+    Rake::Task[task_name].reenable
+    Rake::Task[task_name].invoke
   end
-
-  def mysql_dump_command(config, database_name, backup_file)
-    result = "mysqldump #{database_name} "
-    result += mysql_auth_options(config)
-    result + " > #{backup_file}"
-  end
-
-  def dump_command(config, database_name, backup_file)
-    case config[:adapter]
-      when /mysql/
-        mysql_dump_command(config, database_name, backup_file)
-      when 'postgresql', 'pg'
-        postgres_dump_command(config, database_name, backup_file)
-    end
-  end
-
-  def db_restore_command(config, database_name, backup_file)
-    case config[:adapter]
-      when /mysql/
-        mysql_restore_command(config, database_name, backup_file)
-      when 'postgresql', 'pg'
-        postgres_restore_command(config, database_name, backup_file)
-    end
-  end
-
-  def postgres_restore_command(config, database_name, backup_file)
-    result = "#{postgres_password(config)} pg_restore -d #{database_name} -F c -w #{backup_file}"
-    result += postgres_auth_options(config)
-    result + ' -O -c'
-  end
-
-  def mysql_restore_command(config, database_name, backup_file)
-    "mysql #{database_name} #{mysql_auth_options(config)} < #{backup_file}"
-  end
-
-  def postgres_password(config)
-    "PGPASSWORD='#{config[:password]}'" if config[:password].present?
-  end
-
-  def postgres_auth_options(config)
-    command_options = ''
-    command_options += " -h #{config[:host]}" if config[:host].present?
-    command_options += " -U #{config[:username]}" if config[:username].present?
-    command_options
-  end
-
-  def mysql_auth_options(config)
-    command_options = ''
-    command_options += "--password='#{config[:password]}'" if config[:password].present?
-    command_options += " -h #{config[:host]}" if config[:host].present?
-    command_options += " -u #{config[:username]}" if config[:username].present?
-    command_options
-  end
-
-end
-
-def execute_task!(task_name)
-  Rake::Task[task_name].reenable
-  Rake::Task[task_name].invoke
 end


### PR DESCRIPTION
- This is to support skipping backup and restore
  on SQLServer databases.

- We want to skip all steps in backup and restore when
  deploying to a database on which we don't support such
  tasks yet.